### PR TITLE
Add a banner to the build file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ const esperanto = require('esperanto');
 const browserify = require('browserify');
 const runSequence = require('run-sequence');
 const source = require('vinyl-source-stream');
+const _ = require('lodash');
 
 const manifest = require('./package.json');
 const config = manifest.babelBoilerplateOptions;
@@ -64,6 +65,18 @@ gulp.task('lint-test', function() {
     .pipe($.jshint.reporter('fail'));
 });
 
+function getBanner() {
+  var banner = ['/**',
+    ' * <%= name %> - <%= description %>',
+    ' * @version v<%= version %>',
+    ' * @link <%= homepage %>',
+    ' * @license <%= license %>',
+    ' */',
+    ''].join('\n');
+
+  return _.template(banner)(manifest);
+}
+
 // Build two versions of the library
 gulp.task('build', ['lint-src', 'clean'], function(done) {
   esperanto.bundle({
@@ -71,6 +84,7 @@ gulp.task('build', ['lint-src', 'clean'], function(done) {
     entry: config.entryFileName,
   }).then(function(bundle) {
     var res = bundle.toUmd({
+      banner: getBanner(),
       sourceMap: true,
       sourceMapSource: config.entryFileName + '.js',
       sourceMapFile: exportFileName + '.js',

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-uglifyjs": "^0.6.0",
     "isparta": "^2.0.0",
     "jshint-stylish": "^1.0.0",
+    "lodash": "^3.2.0",
     "mkdirp": "^0.5.0",
     "mocha": "^2.1.0",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
A bit of a noob at gulp.  This works, but the gulp might needs some adjusting.

Essentially this just adds
```js
/**
 * babel-library-boilerplate - Author libraries in ES6 for Node and the browser..
 * @version v3.0.0
 * @link https://github.com/babel/babel-library-boilerplate.git
 * @license MIT
 */
```

For whatever settings you have in the `package.json`

_Simplified to use esperanto's banner_