### PR TITLE
Ensure that Travis fails when Gulp tasks fail

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,7 +122,6 @@ gulp.task('browserify', function() {
 gulp.task('coverage', function(done) {
   require('babel/register')({ modules: 'common' });
   gulp.src(['src/*.js'])
-    .pipe($.plumber())
     .pipe($.istanbul({ instrumenter: isparta.Instrumenter }))
     .pipe($.istanbul.hookRequire())
     .on('finish', function() {
@@ -134,7 +133,6 @@ gulp.task('coverage', function(done) {
 
 function test() {
   return gulp.src(['test/setup/node.js', 'test/unit/**/*.js'], {read: false})
-    .pipe($.plumber())
     .pipe($.mocha({reporter: 'dot', globals: config.mochaGlobals}));
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,6 @@ function jscsNotify(file) {
 // Lint our source code
 gulp.task('lint-src', function() {
   return gulp.src(['src/**/*.js'])
-    .pipe($.plumber())
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))
     .pipe($.notify(jshintNotify))
@@ -55,7 +54,6 @@ gulp.task('lint-src', function() {
 // Lint our test code
 gulp.task('lint-test', function() {
   return gulp.src(['test/**/*.js'])
-    .pipe($.plumber())
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))
     .pipe($.notify(jshintNotify))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,7 @@ gulp.task('browserify', function() {
     .pipe($.livereload());
 });
 
-gulp.task('coverage', function(done) {
+gulp.task('coverage', ['lint-src', 'lint-test'], function(done) {
   require('babel/register')({ modules: 'common' });
   gulp.src(['src/*.js'])
     .pipe($.istanbul({ instrumenter: isparta.Instrumenter }))

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglifyjs": "^0.6.0",
-    "isparta": "^2.0.0",
+    "isparta": "^2.2.0",
     "jshint-stylish": "^1.0.0",
     "mkdirp": "^0.5.0",
     "mocha": "^2.1.0",


### PR DESCRIPTION
Testing #125

There are (at least) two modes of failure that this library can have:

- [x] Unit test fails
- [x] Linting fails

Both of these need to break Travis.