### PR TITLE
Log gulp build errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,7 +93,8 @@ gulp.task('build', ['lint-src', 'clean'], function(done) {
       }))
       .pipe(gulp.dest(destinationFolder))
       .on('end', done);
-  });
+  })
+  .catch(done);
 });
 
 // Bundle our app for our unit tests


### PR DESCRIPTION
Otherwise errors just make the task end (took me a bit of time to figure this out :p)