### PR TITLE
Renamed left over 6to5 -> babel comment

### DIFF
--- a/src/another.js
+++ b/src/another.js
@@ -1,6 +1,6 @@
 //
 // Always be sure to define variables.
-// Never export directly, as 6to5 strips
+// Never export directly, as babel strips
 // all import and export lines.
 //
 


### PR DESCRIPTION
Reading the comment at hand, I'm not even sure this limitation exists still? Is the comment still valid? If so, I guess I don't understand what it means.