### PR TITLE
Update tests to pull in files individually.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import Another from './another';
 
 const MyLibrary = {
-  anotherFn: Another.anotherFn,
+  anotherFn() {
+    return Another.anotherFn() + ', friend';
+  },
   mainFn() {
     return 'hello';
   }

--- a/test/unit/another-test.js
+++ b/test/unit/another-test.js
@@ -1,16 +1,16 @@
-import MyLibrary from '../../src/index';
+import Another from '../../src/another';
 
 describe('A second file of tests', () => {
   beforeEach(() => {
-    spy(MyLibrary, 'anotherFn');
-    MyLibrary.anotherFn();
+    spy(Another, 'anotherFn');
+    Another.anotherFn();
   });
 
   it('should have been run once', () => {
-    expect(MyLibrary.anotherFn).to.have.been.calledOnce;
+    expect(Another.anotherFn).to.have.been.calledOnce;
   });
 
   it('should have always returned ok', () => {
-    expect(MyLibrary.anotherFn).to.have.always.returned('ok');
+    expect(Another.anotherFn).to.have.always.returned('ok');
   });
 });

--- a/test/unit/feature-test.js
+++ b/test/unit/feature-test.js
@@ -1,16 +1,33 @@
 import MyLibrary from '../../src/index';
 
 describe('A feature test', () => {
-  beforeEach(() => {
-    spy(MyLibrary, 'mainFn');
-    MyLibrary.mainFn();
+  describe('one function', () => {
+    beforeEach(() => {
+      spy(MyLibrary, 'mainFn');
+      MyLibrary.mainFn();
+    });
+
+    it('should have been run once', () => {
+      expect(MyLibrary.mainFn).to.have.been.calledOnce;
+    });
+
+    it('should have always returned hello', () => {
+      expect(MyLibrary.mainFn).to.have.always.returned('hello');
+    });
   });
 
-  it('should have been run once', () => {
-    expect(MyLibrary.mainFn).to.have.been.calledOnce;
-  });
+  describe('another function', () => {
+    beforeEach(() => {
+      spy(MyLibrary, 'anotherFn');
+      MyLibrary.anotherFn();
+    });
 
-  it('should have always returned hello', () => {
-    expect(MyLibrary.mainFn).to.have.always.returned('hello');
+    it('should have been run once', () => {
+      expect(MyLibrary.anotherFn).to.have.been.calledOnce;
+    });
+
+    it('should have always returned "ok, friend"', () => {
+      expect(MyLibrary.anotherFn).to.have.always.returned('ok, friend');
+    });
   });
 });


### PR DESCRIPTION
Previously, I wasn't showing off an awesome feature of the boilerplate: even though a single variable and file are exported, in your tests you can pull in the modules individually while testing.

If anyone finds this PR in the future and is interested in stubbing out modules, I haven't yet figured out how to do that. Babel's require override competes with proxyquire's override.